### PR TITLE
fix: lazy loading

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,9 +1,10 @@
 {
-    "diagnostics.globals": [
-        "vim"
-    ],
-    "diagnostics.disable": [
-        "deprecated",
-        "undefined-field"
-    ]
+	"diagnostics.globals": [
+		"vim"
+	],
+	"diagnostics.disable": [
+		"deprecated",
+		"undefined-field",
+		"different-requires"
+	]
 }

--- a/lua/oz/caching/init.lua
+++ b/lua/oz/caching/init.lua
@@ -1,5 +1,4 @@
 local M = {}
-local util = require("oz.util")
 
 local data_dir = vim.fn.stdpath("data")
 local uv = vim.loop
@@ -7,6 +6,7 @@ local uv = vim.loop
 --- Remove a JSON cache file.
 --- @param name string The name of the cache.
 function M.remove_oz_json(name)
+	local util = require("oz.util")
 	local path = data_dir .. "/oz/" .. name .. ".json"
 	if vim.fn.filereadable(path) == 1 then
 		os.remove(path)
@@ -26,6 +26,7 @@ end
 --- @param full_path string
 --- @param content string
 local function write_to_file(full_path, content)
+	local util = require("oz.util")
 	local dir_path = full_path:match("^(.*/)")
 
 	local function create_dir(path)

--- a/lua/oz/git/complete.lua
+++ b/lua/oz/git/complete.lua
@@ -1,5 +1,4 @@
 local M = {}
-local util = require("oz.util")
 
 -- Filter out candidates that are already present in the command line args
 local function filter_suggestions(candidates, used_args, current_arg)
@@ -94,14 +93,15 @@ local function get_git_commands()
 end
 
 local function get_git_branches()
-	return util.shellout_tbl("git for-each-ref --format=%(refname:short) refs/heads/ refs/remotes/")
+	return require("oz.util").shellout_tbl("git for-each-ref --format=%(refname:short) refs/heads/ refs/remotes/")
 end
 
 local function get_git_remotes()
-	return util.shellout_tbl("git remote")
+	return require("oz.util").shellout_tbl("git remote")
 end
 
 local function get_git_files()
+	local util = require("oz.util")
 	local files = util.shellout_tbl("git ls-files")
 	local untracked = util.shellout_tbl("git ls-files --others --exclude-standard")
 	vim.list_extend(files, untracked)

--- a/lua/oz/git/init.lua
+++ b/lua/oz/git/init.lua
@@ -1,8 +1,4 @@
 local M = {}
-local util = require("oz.util")
-local g_util = require("oz.git.util")
-local wizard = require("oz.git.wizard")
-local oz_git_win = require("oz.git.oz_git_win")
 
 M.user_config = nil
 M.running_git_jobs = {}
@@ -13,6 +9,8 @@ M.state = {}
 ---@param args string
 ---@param exit_code number
 local function notify_or_open(output, args, exit_code)
+	local util = require("oz.util")
+	local oz_git_win = require("oz.git.oz_git_win")
 	if #output == 0 then
 		return
 	end
@@ -29,6 +27,8 @@ end
 ---@param args_str string
 ---@return boolean
 local function subcmd_exec(args_tbl, args_str)
+	local util = require("oz.util")
+	local g_util = require("oz.git.util")
 	local cmd = args_tbl[1]
 	local remote_cmds = { "push", "pull", "fetch", "clone", "request-pull", "ls-remote", "submodule", "svn" }
 	local interactive_cmd = { "add -p", "add -i", "reset -p", "commit -p", "checkout -p" }
@@ -73,6 +73,8 @@ local function subcmd_exec(args_tbl, args_str)
 	-- Progress cmds
 	elseif vim.tbl_contains(remote_cmds, cmd) then
 		local command = table.remove(args_tbl, 1)
+		local oz_git_win = require("oz.git.oz_git_win")
+		local wizard = require("oz.git.wizard")
 
 		require("oz.git.remote_cmd").run_git_with_progress(command, args_tbl, function(lines)
 			oz_git_win.open_oz_git_win(lines, args_str)
@@ -125,6 +127,7 @@ end
 --- remove any running jobs.
 ---@param args table
 function M.cleanup_git_jobs(args)
+	local util = require("oz.util")
 	if args then
 		if args.job_id then
 			vim.fn.jobstop(args.job_id)
@@ -158,6 +161,8 @@ end
 ---@param args string arg string
 ---@param stdout_buf boolean show stdout or not?
 function M.run_git_job(args, stdout_buf)
+	local util = require("oz.util")
+	local wizard = require("oz.git.wizard")
 	args = vim.fn.expandcmd(args)
 	local args_table = util.parse_args(args)
 

--- a/lua/oz/git/status/inline_diff.lua
+++ b/lua/oz/git/status/inline_diff.lua
@@ -194,6 +194,40 @@ end
 -- CORE: Optimized Expansion
 -- ============================================================
 
+local function build_display_lines(parsed)
+	local display = {
+		{
+			text = "──────────────────────────────────────────",
+			hl = "OzGitDiffSep",
+			type = "sep",
+		},
+	}
+	for hi, hunk in ipairs(parsed.hunks) do
+		table.insert(display, { text = hunk.header, hl = "OzGitDiffHunkHeader", type = "hunk_header", hunk_index = hi })
+		for li, entry in ipairs(hunk.lines) do
+			local hl = entry.type == "add" and "OzGitDiffAdd"
+				or (
+					entry.type == "del" and "OzGitDiffDel"
+					or (entry.type == "info" and "OzGitDiffSep" or "OzGitDiffContext")
+				)
+			table.insert(display, { text = entry.text, hl = hl, type = entry.type, hunk_index = hi, line_in_hunk = li })
+		end
+		if hi < #parsed.hunks then
+			table.insert(display, {
+				text = "=====================================================================",
+				hl = "OzGitDiffSep",
+				type = "sep",
+			})
+		end
+	end
+	table.insert(display, {
+		text = "──────────────────────────────────────────",
+		hl = "OzGitDiffSep",
+		type = "sep",
+	})
+	return display
+end
+
 function M.toggle_inline_diff(bufnr, file_line, file_path, section, root, rel_path)
 	setup_highlights()
 	bufnr = bufnr or vim.api.nvim_get_current_buf()
@@ -289,46 +323,6 @@ function M.toggle_inline_diff(bufnr, file_line, file_path, section, root, rel_pa
 	}
 
 	M._adjust_lines_after_insert(bufnr, file_line, #display)
-end
-
-function build_display_lines(parsed)
-	local display = {
-		{
-			text = "──────────────────────────────────────────",
-			hl = "OzGitDiffSep",
-			type = "sep",
-		},
-	}
-	for hi, hunk in ipairs(parsed.hunks) do
-		table.insert(display, { text = hunk.header, hl = "OzGitDiffHunkHeader", type = "hunk_header", hunk_index = hi })
-		for li, entry in ipairs(hunk.lines) do
-			local hl = entry.type == "add" and "OzGitDiffAdd"
-				or (
-					entry.type == "del" and "OzGitDiffDel"
-					or (entry.type == "info" and "OzGitDiffSep" or "OzGitDiffContext")
-				)
-			table.insert(display, { text = entry.text, hl = hl, type = entry.type, hunk_index = hi, line_in_hunk = li })
-		end
-		if hi < #parsed.hunks then
-			table.insert(
-				display,
-				{
-					text = "=====================================================================",
-					hl = "OzGitDiffSep",
-					type = "sep",
-				}
-			)
-		end
-	end
-	table.insert(
-		display,
-		{
-			text = "──────────────────────────────────────────",
-			hl = "OzGitDiffSep",
-			type = "sep",
-		}
-	)
-	return display
 end
 
 function M.collapse_inline_diff(bufnr, file_line)
@@ -534,7 +528,7 @@ function M.stage_selection(bufnr)
 
 	for fl, info in pairs(buf_diffs) do
 		if s >= info.diff_start_line and e <= info.diff_end_line then
-			for hi, hr in pairs(info.hunk_ranges) do
+			for _, hr in pairs(info.hunk_ranges) do
 				if not (e < hr.start_line or s > hr.end_line) then
 					local sel = {}
 					for lnum = math.max(s, hr.start_line), math.min(e, hr.end_line) do

--- a/lua/oz/git/user_cmd.lua
+++ b/lua/oz/git/user_cmd.lua
@@ -1,6 +1,4 @@
 local M = {}
-local util = require("oz.util")
-local g_util = require("oz.git.util")
 
 local main
 
@@ -15,6 +13,8 @@ end
 
 --- HANDLE ---
 local function handle_g(opts)
+	local util = require("oz.util")
+	local g_util = require("oz.git.util")
 	if g_util.if_in_git() then
 		if opts.args and #opts.args > 0 then
 			if opts.bang then
@@ -35,6 +35,8 @@ local function handle_g(opts)
 end
 
 local function handle_glog(arg)
+	local util = require("oz.util")
+	local g_util = require("oz.git.util")
 	if g_util.if_in_git() then
 		if arg.args ~= "" then
 			local args_table = util.parse_args(vim.fn.expandcmd(arg.args))
@@ -47,8 +49,8 @@ local function handle_glog(arg)
 	end
 end
 
-
 local function handle_browse(opts)
+	local g_util = require("oz.git.util")
 	local path = vim.trim(opts.args)
 	local oil_path = require("oil").get_current_dir()
 
@@ -62,11 +64,13 @@ local function handle_browse(opts)
 			require("oz.git.browse").browse(path)
 		end
 	else
-		util.Notify("You are not in a git repo.", "warn", "oz_git")
+		require("oz.util").Notify("You are not in a git repo.", "warn", "oz_git")
 	end
 end
 
 local function handle_gwrite(opts)
+	local util = require("oz.util")
+	local g_util = require("oz.git.util")
 	local file_name = vim.trim(opts.args)
 	if g_util.if_in_git() then
 		if opts.range and opts.range > 0 and file_name == "" then
@@ -100,6 +104,8 @@ local function handle_gwrite(opts)
 end
 
 local function handle_gread(opts)
+	local util = require("oz.util")
+	local g_util = require("oz.git.util")
 	if g_util.if_in_git() then
 		local file_name = vim.trim(opts.args)
 		if opts.range and opts.range > 0 and file_name == "" then
@@ -143,6 +149,7 @@ end
 --- user_cmd init
 function M.init()
 	main = require("oz.git")
+	local g_util = require("oz.git.util")
 
 	-- :Git
 	g_util.User_cmd({ "Git", "G" }, function(opts)

--- a/lua/oz/git/util.lua
+++ b/lua/oz/git/util.lua
@@ -1,13 +1,12 @@
 --- @class oz.git.util
 local M = {}
 local original_mappings = {}
-local util = require("oz.util")
 
 --- Check if a path is inside a Git work tree.
 --- @param path? string
 --- @return boolean
 function M.if_in_git(path)
-	return util.if_in_git(path)
+	return require("oz.util").if_in_git(path)
 end
 
 --- Jump to a string in the current buffer.
@@ -81,7 +80,7 @@ end
 --- @param text string
 --- @return boolean
 function M.str_contains_hash(text)
-	return util.str_contains_hash(text)
+	return require("oz.util").str_contains_hash(text)
 end
 
 --- Apply terminal highlighting for diffs.
@@ -157,19 +156,13 @@ end
 --- Get the Git project root.
 --- @return string|nil
 function M.get_project_root()
+	local util = require("oz.util")
 	local root = util.get_git_root()
 	if root then
 		return root
 	else
 		return util.GetProjectRoot()
 	end
-end
-
---- Get a list of branches.
---- @param arg? {loc?: boolean, rem?: boolean}
---- @return string[]
-function M.get_branch(arg)
-	return util.get_branch(arg)
 end
 
 return M

--- a/lua/oz/grep.lua
+++ b/lua/oz/grep.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-local util = require("oz.util")
-
 --- cmd parser
 ---@param cmd string
 ---@return table
@@ -83,6 +81,7 @@ end
 --- show win
 ---@param lines string[]
 local function grep_win(lines)
+	local util = require("oz.util")
 	util.create_win("grep_err", {
 		content = lines,
 		win_type = "bot 7",
@@ -169,7 +168,7 @@ function M.oz_grep(cmd, pattern, dir, opts)
 				elseif #stderr_lines > 0 then
 					grep_win(stdout_lines)
 				else
-					util.Notify("No matches found", "warn", "oz_grep")
+					require("oz.util").Notify("No matches found", "warn", "oz_grep")
 				end
 			end
 		end,
@@ -266,6 +265,7 @@ end
 
 -- :Grep init
 function M.oz_grep_init(config)
+	local util = require("oz.util")
 	-- Grep usercmd
 	vim.api.nvim_create_user_command("Grep", function(opts)
 		local pattern, flags, target_dir

--- a/lua/oz/init.lua
+++ b/lua/oz/init.lua
@@ -49,23 +49,6 @@ local defaults = {
 	},
 }
 
---- vim start with cmd
----@param cmds table
----@return boolean
-local function start_with_cmd(cmds)
-	for i, arg in ipairs(vim.v.argv) do
-		if arg == "-c" and vim.v.argv[i + 1] then
-			for _, cmd in ipairs(cmds) do
-				-- if vim.v.argv[i + 1] == cmd then
-				if vim.startswith(vim.v.argv[i + 1], cmd) then
-					return true
-				end
-			end
-		end
-	end
-	return false
-end
-
 -- Setup function
 function M.setup(opts)
 	-- Merge user-provided options with defaults
@@ -74,46 +57,22 @@ function M.setup(opts)
 
 	-- Initialize oz git
 	if M.config.oz_git then
-		if start_with_cmd({ "G", "Git" }) then
-			require("oz.git").oz_git_usercmd_init(M.config.oz_git)
-		else -- lazy
-			vim.fn.timer_start(10, function()
-				require("oz.git").oz_git_usercmd_init(M.config.oz_git)
-			end)
-		end
+		require("oz.git").oz_git_usercmd_init(M.config.oz_git)
 	end
 
 	-- Initialize :Term
 	if M.config.oz_term then
-		if start_with_cmd({ "Term", "Term!" }) then
-			require("oz.term").Term_init(M.config.oz_term)
-		else -- lazy
-			vim.fn.timer_start(20, function()
-				require("oz.term").Term_init(M.config.oz_term)
-			end)
-		end
+		require("oz.term").Term_init(M.config.oz_term)
 	end
 
 	-- Initialize :Make
 	if M.config.oz_make then
-		if start_with_cmd({ "Make", "Make!" }) then
-			require("oz.make").oz_make_init(M.config.oz_make)
-		else -- lazy
-			vim.fn.timer_start(100, function()
-				require("oz.make").oz_make_init(M.config.oz_make)
-			end)
-		end
+		require("oz.make").oz_make_init(M.config.oz_make)
 	end
 
 	-- Initialize :Grep
 	if M.config.oz_grep then
-		if start_with_cmd({ "Grep", "Grep!" }) then
-			require("oz.grep").oz_grep_init(M.config.oz_grep)
-		else -- lazy
-			vim.fn.timer_start(50, function()
-				require("oz.grep").oz_grep_init(M.config.oz_grep)
-			end)
-		end
+		require("oz.grep").oz_grep_init(M.config.oz_grep)
 	end
 
 	-- Initialize oil integration

--- a/lua/oz/integration/oil.lua
+++ b/lua/oz/integration/oil.lua
@@ -1,8 +1,5 @@
 local M = {}
-local term = require("oz.term")
-local util = require("oz.util")
-local p = require("oz.caching")
-local oil = require("oil")
+
 local json_name = "oilcmd"
 
 local function escape_spaces(s)
@@ -10,6 +7,7 @@ local function escape_spaces(s)
 end
 
 local function get_cur_entry(short)
+	local oil = require("oil")
 	local cursor = oil.get_cursor_entry()
 	local name = cursor.parsed_name or cursor.name
 
@@ -40,6 +38,10 @@ end
 
 -- all the oil specific mappings initialisation
 local function oil_buf_mappings(config, g_mappings)
+	local util = require("oz.util")
+	local term = require("oz.term")
+	local p = require("oz.caching")
+	local oil = require("oil")
 	local term_k = config.mappings.term == "<global>" and g_mappings.Term or config.mappings.term
 
 	if term_k then

--- a/lua/oz/make/init.lua
+++ b/lua/oz/make/init.lua
@@ -1,7 +1,7 @@
 local M = {}
-local util = require("oz.util")
 
 function M.oz_make_init(config)
+	local util = require("oz.util")
 	M.config = config
 
 	-- Make cmd

--- a/lua/oz/term/executor.lua
+++ b/lua/oz/term/executor.lua
@@ -1,17 +1,76 @@
 local M = {}
-local util = require("oz.util")
 
 local entries_cache = {}
+local augroup_created = false
+
+local function apply_win_styling(win, buf)
+	if not vim.api.nvim_win_is_valid(win) or not vim.api.nvim_buf_is_valid(buf) then
+		return
+	end
+	local cmd = vim.b[buf].oz_cmd or ""
+	local wo = vim.wo[win]
+	wo.number = false
+	wo.relativenumber = false
+	wo.signcolumn = "no"
+	wo.wrap = false
+	wo.spell = false
+	wo.list = false
+	wo.winbar = string.format("$ %s", cmd)
+end
+
+local function ensure_augroup()
+	if augroup_created then
+		return
+	end
+	augroup_created = true
+	local group = vim.api.nvim_create_augroup("oz_term_setup", { clear = true })
+
+	vim.api.nvim_create_autocmd("FileType", {
+		pattern = "oz_term",
+		group = group,
+		callback = function(ev)
+			local buf = ev.buf
+			M.highlight(buf)
+			require("oz.term.keymaps").setup(buf)
+			vim.schedule(function()
+				local win = vim.fn.bufwinid(buf)
+				if win ~= -1 then
+					apply_win_styling(win, buf)
+				end
+			end)
+		end,
+	})
+
+	vim.api.nvim_create_autocmd("BufDelete", {
+		pattern = "*",
+		group = group,
+		callback = function(ev)
+			entries_cache[ev.buf] = nil
+		end,
+	})
+
+	vim.api.nvim_create_autocmd("BufWinEnter", {
+		pattern = "*",
+		group = group,
+		callback = function(ev)
+			if vim.bo[ev.buf].filetype == "oz_term" then
+				local win = vim.api.nvim_get_current_win()
+				apply_win_styling(win, ev.buf)
+			end
+		end,
+	})
+end
 
 function M.get_entries(buf)
 	return entries_cache[buf]
 end
 
-local function highlight(buf)
+function M.highlight(buf)
+	local util = require("oz.util")
 	local term_util = require("oz.term.util")
 
-    -- initialization of hls
-    util.setup_hls({ "OzUrl" })
+	-- initialization of hls
+	util.setup_hls({ "OzUrl" })
 
 	vim.api.nvim_buf_call(buf, function()
 		vim.cmd([[
@@ -130,67 +189,17 @@ local function highlight(buf)
 	end)
 end
 
-local function apply_win_styling(win, buf)
-	if not vim.api.nvim_win_is_valid(win) or not vim.api.nvim_buf_is_valid(buf) then
-		return
-	end
-	local cmd = vim.b[buf].oz_cmd or ""
-	local wo = vim.wo[win]
-	wo.number = false
-	wo.relativenumber = false
-	wo.signcolumn = "no"
-	wo.wrap = false
-	wo.spell = false
-	wo.list = false
-	wo.winbar = string.format("$ %s", cmd)
-end
-
-local group = vim.api.nvim_create_augroup("oz_term_setup", { clear = true })
-
-vim.api.nvim_create_autocmd("FileType", {
-	pattern = "oz_term",
-	group = group,
-	callback = function(ev)
-		local buf = ev.buf
-		highlight(buf)
-		require("oz.term.keymaps").setup(buf)
-		vim.schedule(function()
-			local win = vim.fn.bufwinid(buf)
-			if win ~= -1 then
-				apply_win_styling(win, buf)
-			end
-		end)
-	end,
-})
-
-vim.api.nvim_create_autocmd("BufDelete", {
-	pattern = "*",
-	group = group,
-	callback = function(ev)
-		entries_cache[ev.buf] = nil
-	end,
-})
-
-vim.api.nvim_create_autocmd("BufWinEnter", {
-	pattern = "*",
-	group = group,
-	callback = function(ev)
-		if vim.bo[ev.buf].filetype == "oz_term" then
-			local win = vim.api.nvim_get_current_win()
-			apply_win_styling(win, ev.buf)
-		end
-	end,
-})
-
 --- run
 ---@param cmd string shell cmd
 ---@param opts {cwd: string, stdin: string, hidden: boolean}? runs the cmd then put the stdout into a buffer
 function M.run(cmd, opts)
+	ensure_augroup()
 	if not cmd or cmd == "" then
 		return
 	end
 	cmd = vim.fn.expandcmd(cmd)
 	opts = opts or {}
+	local util = require("oz.util")
 	local manager = require("oz.term.manager")
 	local target_id = manager.get_target_id()
 	local target_inst = target_id and manager.instances[target_id]

--- a/lua/oz/term/init.lua
+++ b/lua/oz/term/init.lua
@@ -1,10 +1,10 @@
 local M = {}
-local util = require("oz.util")
 
 M.cached_cmd = nil
 M.term_cmd_ft = nil
 
 local function term_cmd_init(config)
+	local util = require("oz.util")
 	local function complete(arg_lead)
 		local manager = require("oz.term.manager")
 		local ids = {}

--- a/lua/oz/term/util.lua
+++ b/lua/oz/term/util.lua
@@ -1,6 +1,5 @@
 --- @class oz.term.util
 local M = {}
-local util = require("oz.util")
 
 M.EFM_PATTERNS = {
 	"%f:%l:%c: %m",
@@ -22,7 +21,7 @@ M.PATH_PATTERN = [[\v[a-zA-Z0-9./\_%@~-]{2,}%([:()]\d+)*]]
 --- @param cache table<string, boolean>
 --- @return boolean
 function M.is_readable(path, cache)
-	return util.is_readable(path, cache)
+	return require("oz.util").is_readable(path, cache)
 end
 
 --- Find a valid readable path from a string and CWD.
@@ -30,7 +29,7 @@ end
 --- @param cwd string
 --- @return string|nil
 function M.find_valid_path(path, cwd)
-	return util.find_valid_path(path, cwd)
+	return require("oz.util").find_valid_path(path, cwd)
 end
 
 --- Get the current working directory for a given buffer.

--- a/lua/oz/util/picker.lua
+++ b/lua/oz/util/picker.lua
@@ -10,18 +10,25 @@ local nvim_buf_clear_namespace = api.nvim_buf_clear_namespace
 local nvim_win_is_valid = api.nvim_win_is_valid
 local nvim_set_option_value = api.nvim_set_option_value
 
-local state = {
-	ns = api.nvim_create_namespace("picker"),
-	prompt_ns = api.nvim_create_namespace("picker_prompt"),
-	title_ns = api.nvim_create_namespace("picker_title"),
-	items = {},
-	filtered = {},
-	keys = {},
-	key_to_items = {},
-	selected = 0,
-	query = "",
-	closing = false,
-}
+local state = nil
+
+local function get_state()
+	if not state then
+		state = {
+			ns = api.nvim_create_namespace("picker"),
+			prompt_ns = api.nvim_create_namespace("picker_prompt"),
+			title_ns = api.nvim_create_namespace("picker_title"),
+			items = {},
+			filtered = {},
+			keys = {},
+			key_to_items = {},
+			selected = 0,
+			query = "",
+			closing = false,
+		}
+	end
+	return state
+end
 
 local function setup_highlights()
 	require("oz.util.hl").setup_hls({
@@ -49,6 +56,7 @@ local function normalize_items(items)
 end
 
 local function close_picker()
+	local state = get_state()
 	if state.closing then
 		return
 	end
@@ -102,6 +110,7 @@ local function close_picker()
 end
 
 local function render_results()
+	local state = get_state()
 	local buf = state.result_buf
 	if not buf or state.closing then
 		return
@@ -151,6 +160,7 @@ local function render_results()
 end
 
 local function on_type()
+	local state = get_state()
 	if state.closing or not state.prompt_buf then
 		return
 	end
@@ -209,6 +219,7 @@ end
 --- @param items oz.util.picker.item[] List of items to pick from.
 --- @param opts oz.util.picker.opts Configuration options.
 function M.pick(items, opts)
+	local state = get_state()
 	opts = opts or {}
 	local on_select = opts.on_select
 	assert(on_select, "on_select required")

--- a/lua/oz/util/progress.lua
+++ b/lua/oz/util/progress.lua
@@ -1,7 +1,6 @@
 --- @class oz.util.progress
 local M = {}
-local has_fidget = pcall(require, "fidget")
-local fidget = has_fidget and require("fidget.progress") or nil
+
 M.progress_tbl = {}
 
 local spinner_frames = { "⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷" }
@@ -11,6 +10,11 @@ local spinner_active = false
 local progress_percentage = 0
 local progress_update_timer = nil
 local progress_increment_value = 5
+
+local function get_fidget()
+	local has_fidget = pcall(require, "fidget")
+	return has_fidget and require("fidget.progress") or nil
+end
 
 --- Update spinner animation.
 --- @return string|nil The next frame of the spinner.
@@ -28,6 +32,8 @@ local function start_spinner_updates(unique_id)
 	if progress_update_timer then
 		return
 	end
+
+	local fidget = get_fidget()
 
 	-- WTF: for some shit reason i can't access M.progress_tbl items by passing index
 	local fidget_handle
@@ -75,6 +81,7 @@ end
 --- @param unique_id string
 ---@param opts {title: string, fidget_lsp?: string, message?: string, manual?: boolean}
 function M.start_progress(unique_id, opts)
+	local fidget = get_fidget()
 	local msg = opts.message or "in progress..."
 	spinner_active = true
 	if fidget then
@@ -118,6 +125,7 @@ end
 --- @param percentage number
 --- @param message string
 function M.update_progress(unique_id, percentage, message)
+	local fidget = get_fidget()
 	progress_percentage = percentage
 
 	local fidget_handle = M.progress_tbl[unique_id .. "_fidget_handle"]
@@ -133,8 +141,9 @@ end
 --- @param unique_id string
 ---@param opts {title: string, exit_code: integer, message?: string[]}
 function M.stop_progress(unique_id, opts)
+	local fidget = get_fidget()
 	local msg = opts.message and (opts.exit_code == 0 and opts.message[1] or opts.message[2])
-		or (opts.exit_code == 0 and "completed successfully" or "failed")
+	or (opts.exit_code == 0 and "completed successfully" or "failed")
 	spinner_active = false
 
 	local fidget_handle = M.progress_tbl[unique_id .. "_fidget_handle"]


### PR DESCRIPTION
The lazy loading logic leads to a race condition when lazy loading with a plugin manager: e.g., with Lazy.nvim, with :G as the trigger, the plugin gets loaded but it leads to an error because the G command will only be defined 10ms later.

I couldn't figure out the purpose of this logic, so here's a patch to remove it and fix lazy loading with plugin managers.