### PR TITLE
fix(oz_term): stop insert mode for background jobs

### DIFF
--- a/lua/oz/term/executor.lua
+++ b/lua/oz/term/executor.lua
@@ -276,6 +276,7 @@ function M.run(cmd, opts)
 	if opts.hidden then
 		terminal_buf = vim.api.nvim_create_buf(false, true)
 		setup_terminal(terminal_buf, nil)
+		vim.cmd.stopinsert()
 	else
 		-- create a new window or reuse existing
 		util.create_win("oz_term", {


### PR DESCRIPTION
Users usually call the `:Term!` background command from normal mode, so it's strange to then put them into insert mode afterwards. With this change, insert mode mode is now stopped before finishing the background job execution.