### PR TITLE
fix(oz_make): expand wildcards and special chars

### DIFF
--- a/lua/oz/git/init.lua
+++ b/lua/oz/git/init.lua
@@ -158,7 +158,6 @@ end
 ---@param args string arg string
 ---@param stdout_buf boolean show stdout or not?
 function M.run_git_job(args, stdout_buf)
-	args = vim.fn.expandcmd(args)
 	local args_table = util.parse_args(args)
 
 	local suggestion = nil

--- a/lua/oz/git/user_cmd.lua
+++ b/lua/oz/git/user_cmd.lua
@@ -37,7 +37,7 @@ end
 local function handle_glog(arg)
 	if g_util.if_in_git() then
 		if arg.args ~= "" then
-			local args_table = util.parse_args(vim.fn.expandcmd(arg.args))
+			local args_table = util.parse_args(arg.args)
 			require("oz.git.log").commit_log({ level = 1 }, args_table)
 		else
 			require("oz.git.log").commit_log()

--- a/lua/oz/make/job.lua
+++ b/lua/oz/make/job.lua
@@ -22,7 +22,7 @@ function M.Make_func(arg_str, dir, config)
 	end
 
 	dir = dir or vim.fn.getcwd()
-	local cmd_tbl = util.parse_args(arg_str)
+	local cmd_tbl = util.parse_args(vim.fn.expandcmd(arg_str))
 	local make_cmd = require("oz.make.auto").get_makeprg(dir)
 
 	if vim.bo.makeprg == "" then
@@ -32,7 +32,7 @@ function M.Make_func(arg_str, dir, config)
 		end
 	end
 
-	local make_cmd_tbl = util.parse_args(make_cmd)
+	local make_cmd_tbl = util.parse_args(vim.fn.expandcmd(make_cmd))
 	for i = #make_cmd_tbl, 1, -1 do
 		table.insert(cmd_tbl, 1, make_cmd_tbl[i])
 	end

--- a/lua/oz/make/job.lua
+++ b/lua/oz/make/job.lua
@@ -22,7 +22,7 @@ function M.Make_func(arg_str, dir, config)
 	end
 
 	dir = dir or vim.fn.getcwd()
-	local cmd_tbl = util.parse_args(vim.fn.expandcmd(arg_str))
+	local cmd_tbl = util.parse_args(arg_str)
 	local make_cmd = require("oz.make.auto").get_makeprg(dir)
 
 	if vim.bo.makeprg == "" then
@@ -32,7 +32,7 @@ function M.Make_func(arg_str, dir, config)
 		end
 	end
 
-	local make_cmd_tbl = util.parse_args(vim.fn.expandcmd(make_cmd))
+	local make_cmd_tbl = util.parse_args(make_cmd)
 	for i = #make_cmd_tbl, 1, -1 do
 		table.insert(cmd_tbl, 1, make_cmd_tbl[i])
 	end

--- a/lua/oz/util/parse_args.lua
+++ b/lua/oz/util/parse_args.lua
@@ -4,6 +4,9 @@ local M = {}
 --- @param argstring string The string to parse.
 --- @return string[] A table of parsed arguments.
 function M.parse_args(argstring)
+    -- Expand wildcards and special characters
+	argstring = vim.fn.expandcmd(argstring)
+
 	local args = {}
 	local i = 1
 	local len = #argstring


### PR DESCRIPTION
Given a `main.c` file with the following setting:

```
:set makeprg=gcc\ %
```

Running `:Make` will now result in the following command:

```
gcc main.c
```

Which is consistent with the builtin `:make` command.

In addition, the arguments passed to the `:Make` command are now expanded. So, setting `:set makeprg=gcc` and `:Make %` is also valid.